### PR TITLE
Replaced preg_replace() with preg_replace_callback()

### DIFF
--- a/Freeagent.php
+++ b/Freeagent.php
@@ -125,7 +125,8 @@ class Freeagent {
 		
 		foreach ($fields as $field){
 			if (preg_match('/([^:]+): (.+)/m', $field, $match)){
-				$match[1] = preg_replace('/(?<=^|[\x09\x20\x2D])./e', 'strtoupper("\0")', strtolower(trim($match[1])));
+				$match[1] = preg_replace_callback('/(?<=^|[\x09\x20\x2D])./',
+                    create_function ('$matches', 'return strtoupper("\0");'), strtolower(trim($match[1])));
 				if (isset($retVal[$match[1]])){
 					$retVal[$match[1]] = array($retVal[$match[1]], $match[2]);
 				} else {


### PR DESCRIPTION
The /e modifier is deprecated in PHP 5. According to PHP docs preg_replace_callback() works with PHP 4 >= 4.0.5, PHP 5
